### PR TITLE
Update mocha to ^5.2.0 to fix critical npm audit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "benchmark": "^2.1.1",
     "chai": "^3.5.0",
     "lodash.get": "^4.4.2",
-    "mocha": "^3.0.2"
+    "mocha": "^5.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running `npm install`, I got a critical warning from npm. I fixed it by updating `mocha` to `^5.2.0`, as recommended by npm.

It is marked as a potentially breaking change, but after running `npm test`, it still shows 9 passing tests, and everything still works.

It's a small PR, but I hope it helps!